### PR TITLE
Fix import in UpdateAuthorDto and remove unnecessary newline

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,7 +7,6 @@ import { LibraryModule } from './feature/library/library.module';
 import { AuthorsModule } from './feature/authors/authors.module';
 import { EditorialModule } from './feature/editorial/editorial.module';
 
-
 @Module({
   imports: [
     ConfigModule.forRoot(),

--- a/src/feature/authors/dto/update-author.dto.ts
+++ b/src/feature/authors/dto/update-author.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { PartialType } from '@nestjs/swagger';
 import { CreateAuthorDto } from './create-author.dto';
 
 export class UpdateAuthorDto extends PartialType(CreateAuthorDto) {}


### PR DESCRIPTION
Replaced the `PartialType` import source in `UpdateAuthorDto` to use `@nestjs/swagger` instead of `@nestjs/mapped-types` for compatibility. Additionally, removed an extraneous newline in `app.module.ts` to enhance code readability.